### PR TITLE
Finalized mouseover and mouseout

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,17 @@
       display: flex;
       flex-direction: column;
       min-height: 200px;
+
     }
-    
+
+    .panel.highlight:not(.open):not(.open-active){
+      box-shadow: inset 0 0 20px 20px rgba(76, 84, 181, 0.3); /*Halo effect*/
+      transition: 0.3s ease-in-out; /*smooth transitions out a bit*/
+      filter: brightness(1.05); /*makes image and text slightly brighter*/
+      transform: scale(1.1); /*Makes the cursor-on element tiny bit larger to further create hover effect*/
+      cursor: pointer; /*illusion of interactivity*/
+    }
+
 
     .panel1 { background-image: url(/imageForFlexPanelAssignment/swedenBackground1.jpg); }
     .panel2 { background-image: url(/imageForFlexPanelAssignment/swedenBackground2.jpg); }
@@ -108,13 +117,6 @@
       flex: 3;
       font-size: 25px;
     }
-
-    .panel:not(.open):not(.open-active):hover{ /*using psuedo classes to target panels that don't have the open and open-active to make the hover effect more prominent*/
-      box-shadow: inset 0 0 10px 10px rgba(75, 83, 173, 0.3);
-      transform: scale(1.01); /*Makes the cursor-on element tiny bit larger to further create hover effect*/
-      cursor: pointer;
-    }
-    /*avoids having to tie hover to open and potential errors with transitionend*/
 
   </style>
 
@@ -184,6 +186,23 @@
 
   <script>
     const panels = document.querySelectorAll('.panel');
+
+    const hoverEffect = document.querySelectorAll('.panel'); //seperate variable to refer to hover effect, for the sake of clarity to differentiate from base code
+
+    hoverEffect.forEach(function(panelElement){ //since its a node-list, we need a forEach loop to check this function against everything that has .panel on it
+      //
+      panelElement.addEventListener("mouseover", function(){
+        this.classList.add("highlight");
+      }); //wherever your mouse on currently on, you add highlight
+
+      panelElement.addEventListener("mouseout", function(){
+        this.classList.remove("highlight");
+      });//whereever your mouse is NOT currently on, you remove highlight (to check to make sure highlight didnt get stuck due to transitionend)
+
+    });//Upon hovering, we're checking to see where my mouse is, and based on where it is, it'll trigger this function
+    //which will add the highlight class on where im hovering over OR remove it if I am not hovering over it(or it will not add it if it doesnt have it)
+    //The remove also acts as a bit of a safe guard since previously ran into issues with transitionend interrupting animation and vice versa
+    //The hoverEffect targets the divs because of .panel and the function for panelElement parameter is what is executed as the mouseover or mouseout happens
 
     function toggleOpen() {
       console.log('Hello');


### PR DESCRIPTION
Added event listeners to mouseover and mouseout to simulate hovereffect. This time, there is not bugs with transitionend because the effect removal isnt dependent on the transition at all but is instead class specific and depends on whether the class is removed or not. This will replace previous hover effect using psuedoclasses and css :hover

Fixes-Bug: n/a
Implements-Requirement: n/a